### PR TITLE
Attempt to remove all gdk threads_enter and leave calls

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -130,6 +130,7 @@ nobase_pkgdata_DATA=					\
 	smburi.py					\
 	statereason.py					\
 	timedops.py					\
+	thread_operations.py				\
 	ToolbarSearchEntry.py				\
 	userdefault.py					\
 	ui/AboutDialog.ui				\

--- a/system-config-printer.py
+++ b/system-config-printer.py
@@ -23,9 +23,8 @@
 
 # config is generated from config.py.in by configure
 import config
-
 import sys, os, time, re
-import _thread
+import threading
 import dbus
 import gi
 try:
@@ -94,6 +93,7 @@ import statereason
 import newprinter
 from newprinter import busy, ready
 import printerproperties
+from thread_operations import thread_safe_blocking_call, SCP_MAIN_THREAD_NAME
 
 import ppdippstr
 ppdippstr.init ()
@@ -749,6 +749,7 @@ class GUI(GtkGUI):
         except RuntimeError:
             self.monitor.update ()
 
+    @thread_safe_blocking_call
     def setConnected(self):
         connected = bool(self.cups)
 
@@ -830,6 +831,7 @@ class GUI(GtkGUI):
         known_servers.sort()
         return known_servers
 
+    @thread_safe_blocking_call
     def populateList(self, prompt_allowed=True):
         # Save selection of printers.
         selected_printers = set()
@@ -1178,19 +1180,17 @@ class GUI(GtkGUI):
         cups.setUser('')
         self.connect_user = cups.getUser()
         # Now start a new thread for connection.
-        self.connect_thread = _thread.start_new_thread(self.connect,
-                                                      (self.PrintersWindow,))
+        self.connect_thread = threading.Thread(target=self.connect,
+                                               name="SCP_CONNECTING_THREAD"
+                                               )
+        self.connect_thread.start()
 
     def update_connecting_pbar (self):
         ret = True
-        Gdk.threads_enter ()
-        try:
-            if not self.ConnectingDialog.get_property ("visible"):
-                ret = False # stop animation
-            else:
-                self.pbarConnecting.pulse ()
-        finally:
-            Gdk.threads_leave ()
+        if not self.ConnectingDialog.get_property ("visible"):
+            ret = False # stop animation
+        else:
+            self.pbarConnecting.pulse ()
 
         return ret
 
@@ -1207,7 +1207,7 @@ class GUI(GtkGUI):
         self.connect_thread = None
         self.ConnectingDialog.hide()
 
-    def connect(self, parent=None):
+    def connect(self):
         """
         Open a connection to a new server. Is executed in a separate thread!
         """
@@ -1232,42 +1232,44 @@ class GUI(GtkGUI):
                 nonfatalException ()
 
         try:
-            connection = authconn.Connection(parent,
+            connection = authconn.Connection(self.PrintersWindow,
                                              host=self.connect_server,
                                              encryption=self.connect_encrypt)
         except RuntimeError as s:
-            if self.connect_thread != _thread.get_ident(): return
-            Gdk.threads_enter()
-            try:
-                self.ConnectingDialog.hide()
-                self.cups = None
-                self.setConnected()
-                self.populateList()
-                show_IPP_Error(None, s, parent)
-            finally:
-                Gdk.threads_leave()
+            if self.connect_thread != threading.currentThread(): return
+            Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE,
+                                 self.ConnectingDialog.hide,
+                                 )
+            self.cups = None
+            self.setConnected()
+            self.populateList()
+            Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE,
+                                 show_IPP_Error,
+                                 None, s, self.PrintersWindow
+                                 )
             return
         except cups.IPPError as e:
             (e, s) = e.args
-            if self.connect_thread != _thread.get_ident(): return
-            Gdk.threads_enter()
-            try:
-                self.ConnectingDialog.hide()
-                self.cups = None
-                self.setConnected()
-                self.populateList()
-                show_IPP_Error(e, s, parent)
-            finally:
-                Gdk.threads_leave()
+            if self.connect_thread != threading.currentThread(): return
+            Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE,
+                                 self.ConnectingDialog.hide,
+                                 )
+            self.cups = None
+            self.setConnected()
+            self.populateList()
+            Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE,
+                                 show_IPP_Error,
+                                 None, s, self.PrintersWindow
+                                 )
             return
         except:
             nonfatalException ()
 
-        if self.connect_thread != _thread.get_ident(): return
-        Gdk.threads_enter()
-
+        if self.connect_thread != threading.currentThread(): return
         try:
-            self.ConnectingDialog.hide()
+            Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE,
+                                 self.ConnectingDialog.hide,
+                                 )
             self.cups = connection
             self.setConnected()
             self.populateList()
@@ -1276,11 +1278,12 @@ class GUI(GtkGUI):
             self.cups = None
             self.setConnected()
             self.populateList()
-            show_HTTP_Error(s, parent)
+            Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE,
+                                 show_HTTP_Error,
+                                 s, self.PrintersWindow
+                                 )
         except:
             nonfatalException ()
-
-        Gdk.threads_leave()
 
     def reconnect (self):
         """Reconnect to CUPS after the server has reloaded."""
@@ -2058,23 +2061,19 @@ class GUI(GtkGUI):
         GLib.timeout_add_seconds (1, self.service_started_try)
 
     def service_started_try (self):
-        Gdk.threads_enter ()
-        try:
-            self.on_btnRefresh_clicked (None)
-        finally:
-            Gdk.threads_leave ()
+        Gdk.threads_add_idle(GLib.PRIORITY_DEFAULT_IDLE,
+                             self.on_btnRefresh_clicked,
+                             None
+                             )
+
 
         GLib.timeout_add_seconds (1, self.service_started_retry)
         return False
 
     def service_started_retry (self):
         if not self.cups:
-            Gdk.threads_enter ()
-            try:
                 self.on_btnRefresh_clicked (None)
                 self.btnStartService.set_sensitive (True)
-            finally:
-                Gdk.threads_leave ()
 
         return False
 
@@ -2180,11 +2179,7 @@ class GUI(GtkGUI):
     def defer_refresh (self):
         def deferred_refresh ():
             self.populateList_timer = None
-            Gdk.threads_enter ()
-            try:
-                self.populateList (prompt_allowed=False)
-            finally:
-                Gdk.threads_leave ()
+            self.populateList (prompt_allowed=False)
             return False
 
         if self.populateList_timer:
@@ -2222,6 +2217,8 @@ class GUI(GtkGUI):
 
 def main(show_jobs):
     cups.setUser (os.environ.get ("CUPS_USER", cups.getUser()))
+    # set name for main thread
+    threading.currentThread().setName(SCP_MAIN_THREAD_NAME)
     Gdk.threads_init ()
     from dbus.glib import DBusGMainLoop
     DBusGMainLoop (set_as_default=True)
@@ -2233,11 +2230,7 @@ def main(show_jobs):
     else:
         mainwindow = GUI()
 
-    Gdk.threads_enter ()
-    try:
-        Gtk.main()
-    finally:
-        Gdk.threads_leave ()
+    Gtk.main()
 
 if __name__ == "__main__":
     import getopt

--- a/thread_operations.py
+++ b/thread_operations.py
@@ -1,0 +1,30 @@
+import threading
+gi.require_version('Gdk', '3.0')
+from gi.repository import Gdk, GLib
+
+SCP_MAIN_THREAD_NAME = "SCP_MAIN_THREAD"
+
+def thread_safe_blocking_call(function):
+    """ Make function/method thread safe and block until its call is finished
+    """
+
+    blocker = threading.Event()
+
+    def inner_wrapper(*args, **kwargs):
+        function(*args, **kwargs)
+        blocker.set()
+        return False
+
+    def wrapper(*args, **kwargs):
+        # if this is the main thread then simply return function
+        if threading.current_thread().name == SCP_MAIN_THREAD_NAME:
+            return function(*args, **kwargs)
+        Gdk.threads_add_idle(
+        GLib.PRIORITY_DEFAULT_IDLE,
+        inner_wrapper,
+        *args,
+        **kwargs
+        )
+        blocker.wait()
+
+    return wrapper


### PR DESCRIPTION
Hi,
This pullrequest is an attempt to invent a way how to get rid of gdk threads* calls, which are deprecated.
If you will agree with this way then i will rewrite the rest of system-config-printer to use this instead of gdk threads.
Feel free to propose any change.