### PR TITLE
fix translation in troubleshoot menu

### DIFF
--- a/troubleshoot/base.py
+++ b/troubleshoot/base.py
@@ -21,12 +21,14 @@
 ## Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from gi.repository import Gtk
-from gettext import gettext as _
 N_ = lambda x: x
 from debug import *
 
-__all__ = [ '_',
-            'debugprint', 'get_debugging', 'set_debugging',
+import config
+import gettext
+gettext.install(domain=config.PACKAGE, localedir=config.localedir)
+
+__all__ = [ 'debugprint', 'get_debugging', 'set_debugging',
             'Question',
             'Multichoice',
             'TEXT_start_print_admin_tool' ]


### PR DESCRIPTION
Fix translation in troubleshoot menu.

    Replaced the function '_' with the correct one.
    => The correct domain name is being loaded ('system-config-printer').

