### PR TITLE
Fix non-responding gui on remote xserver connection via TCP protocol

### DIFF
--- a/asyncipp.py
+++ b/asyncipp.py
@@ -175,44 +175,43 @@ class _IPPConnectionThread(threading.Thread):
 
     def _auth (self, prompt, conn=None, method=None, resource=None):
         def prompt_auth (prompt):
-            Gdk.threads_enter ()
             if conn is None:
                 self._auth_handler (prompt, self._conn)
             else:
                 self._auth_handler (prompt, self._conn, method, resource)
-
-            Gdk.threads_leave ()
             return False
 
         if self._auth_handler is None:
             return ""
 
-        GLib.idle_add (prompt_auth, prompt)
+        GLib.idle_add (prompt_auth, prompt, priority=config.gui_events_priority)
         password = self._auth_queue.get ()
         return password
 
     def _reply (self, result):
         def send_reply (handler, result):
             if not self._destroyed:
-                Gdk.threads_enter ()
                 handler (self._conn, result)
-                Gdk.threads_leave ()
             return False
 
         if not self._destroyed and self._reply_handler:
-            GLib.idle_add (send_reply, self._reply_handler, result)
+            GLib.idle_add (send_reply,
+                           self._reply_handler,
+                           result,
+                           priority=config.gui_events_priority)
 
     def _error (self, exc):
         def send_error (handler, exc):
             if not self._destroyed:
-                Gdk.threads_enter ()
                 handler (self._conn, exc)
-                Gdk.threads_leave ()
             return False
 
         if not self._destroyed and self._error_handler:
             debugprint ("Add %s to idle" % self._error_handler)
-            GLib.idle_add (send_error, self._error_handler, exc)
+            GLib.idle_add (send_error,
+                           self._error_handler,
+                           exc,
+                           priority=config.gui_events_priority)
 
 ###
 ### This is the user-visible class.  Although it does not inherit from

--- a/config.py.in
+++ b/config.py.in
@@ -18,6 +18,8 @@
 ## along with this program; if not, write to the Free Software
 ## Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from gi.repository import GLib
+
 prefix="@prefix@"
 datadir="@datadir@"
 localedir="@localedir@"
@@ -28,3 +30,4 @@ DOWNLOADABLE_ONLYPPD=True
 DOWNLOADABLE_ONLYFREE=True
 DOWNLOADABLE_PKG_ONLYSIGNED=True
 packagesystem = None # discovered at runtime
+gui_events_priority=GLib.PRIORITY_DEFAULT_IDLE

--- a/newprinter.py
+++ b/newprinter.py
@@ -3466,7 +3466,9 @@ class NewPrinterGUI(GtkGUI):
             if self.printer_finder is None:
                 return
 
-            GLib.idle_add (self.found_network_printer_callback, new_device)
+            GLib.idle_add (self.found_network_printer_callback,
+                           new_device,
+                           priority=config.gui_events_priority)
 
         self.btnNetworkFind.set_sensitive (False)
         self.entNPTNetworkHostname.set_sensitive (False)

--- a/ppdcache.py
+++ b/ppdcache.py
@@ -28,6 +28,8 @@ from shutil import copyfileobj
 from tempfile import NamedTemporaryFile
 from debug import *
 
+import config
+
 cups.require ("1.9.50")
 
 class PPDCache:
@@ -180,7 +182,12 @@ class PPDCache:
             Gdk.threads_leave ()
             return False
 
-        GLib.idle_add (cb_func, callback, name, result, exc)
+        GLib.idle_add (cb_func,
+                       callback,
+                       name,
+                       result,
+                       exc,
+                       priority=config.gui_events_priority)
 
 if __name__ == "__main__":
     import sys

--- a/system-config-printer.py
+++ b/system-config-printer.py
@@ -2244,7 +2244,11 @@ if __name__ == "__main__":
     try:
         opts, args = getopt.gnu_getopt (sys.argv[1:], '',
                                         ['embedded=',
-                                            'debug', 'show-jobs='])
+                                         'debug',
+                                         'show-jobs=',
+                                         'prioritize-glib-events'
+                                        ]
+                                       )
     except getopt.GetoptError:
         show_help ()
         sys.exit (1)
@@ -2260,5 +2264,8 @@ if __name__ == "__main__":
 
         if opt == "--embedded":
             PlugWindowId = int(optarg)
+
+        if opt == "--prioritize-glib-events":
+            config.gui_events_priority=GLib.PRIORITY_HIGH_IDLE
 
     main(show_jobs)


### PR DESCRIPTION
Remove unnecessary gdk_threads_enter/leave calls

Add new option --prioritize-glib-calls which causes GLib to
give more attention to our asynchronous calls