### PR TITLE
Fix "remember password" feature

### DIFF
--- a/jobviewer.py
+++ b/jobviewer.py
@@ -92,8 +92,8 @@ if USE_SECRET:
         service = Secret.Service()
     
         def __init__(self):
-            self.service = Secret.Service.get(0,
-                                              None)
+            self.service = Secret.Service.get_sync(0,
+                                                   None)
     
         def get_service(self):
             return self.service

--- a/jobviewer.py
+++ b/jobviewer.py
@@ -91,36 +91,26 @@ if USE_SECRET:
     class ServiceGet:
         service = Secret.Service()
     
-        def on_get_service(self, source, result, unused):
-            service = Secret.Service.get_finish(result)
-    
         def __init__(self):
-            Secret.Service.get(0,
-                               None,
-                               self.on_get_service,
-                               None)
+            self.service = Secret.Service.get(0,
+                                              None)
     
         def get_service(self):
-            return ServiceGet.service
+            return self.service
     
     
     class ItemSearch:
         items = list()
     
-        def on_search_item(self, source, result, unused):
-            items = Secret.Service.search_finish(None, result)
-    
         def __init__(self, service, attrs):
-            Secret.Service.search(service,
-                                  NETWORK_PASSWORD,
-                                  attrs,
-                                  Secret.SearchFlags.LOAD_SECRETS,
-                                  None,
-                                  self.on_search_item,
-                                  None)
+            self.items = Secret.Service.search_sync(service,
+                                                    NETWORK_PASSWORD,
+                                                    attrs,
+                                                    Secret.SearchFlags.LOAD_SECRETS,
+                                                    None)
     
         def get_items(self):
-            return ItemSearch.items
+            return self.items
     
     
     class PasswordStore:

--- a/jobviewer.py
+++ b/jobviewer.py
@@ -1049,20 +1049,10 @@ class JobViewer (GtkGUI):
                     if items:
                         auth_info = ['' for x in auth_info_required]
                         ind = auth_info_required.index ('username')
-
-                        for attr in items[0].attributes:
-                            # It might be safe to assume here that the
-                            # user element is always the second item in a
-                            # NETWORK_PASSWORD element but lets make sure.
-                            if attr.name == 'user':
-                                auth_info[ind] = attr.get_string()
-                                break
-                        else:
-                            debugprint ("Did not find username keyring "
-                                        "attributes.")
+                        auth_info[ind] = items[0].get_attributes().get("user")
 
                         ind = auth_info_required.index ('password')
-                        auth_info[ind] = items[0].secret
+                        auth_info[ind] = items[0].get_secret().get().decode()
                         break
                 else:
                     debugprint ("Failed to find secret in keyring.")


### PR DESCRIPTION
Right now, while saving the password to the keyring works perfectly (when "Remember Password" is picked), loading from the keyring fails.

There's 2 issues at hand here:
- `gi.Secret.Service` doesn't work async on python for some reason. The _final never fires. I could replicate this issue on a variety of distributions. So to fix this, I moved those functions to the relevant sync methods. While this isn't ideal, it fixes the bug at hand. `gi.Secret.PasswordStore` does seem to work.
- The .secret and .attribute functions of Secret.Item objects give out `gi.overrides.Gio._DBusProxyMethodCall` objects, not the actual contents. I ended up using `.get_secret().get()` (returns `bytes`) and `.get_attributes()["user"]` (returns `str`). I feel like the change on user especially was important, as the last one involved a for loop through the entire array.

This PR fixes both of them. Tested and confirmed working.