### PR TITLE
Make the matching rule of printer device path more flexible

### DIFF
--- a/udev/70-printers.rules
+++ b/udev/70-printers.rules
@@ -1,4 +1,4 @@
 # Low-level USB device add trigger
 ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{ID_USB_INTERFACES}=="*:0701??:*", TAG+="systemd", ENV{SYSTEMD_WANTS}="configure-printer@usb-$env{BUSNUM}-$env{DEVNUM}.service"
 # Low-level USB device remove trigger
-ACTION=="remove", SUBSYSTEM=="usb", ENV{ID_USB_INTERFACES}=="*:0701*:*", RUN+="udev-configure-printer remove %p"
+ACTION=="remove", SUBSYSTEM=="usb", ENV{INTERFACE}=="7/1/*", ENV{INTERFACE}!="7/1/4", RUN+="udev-configure-printer remove %p"

--- a/udev/70-printers.rules
+++ b/udev/70-printers.rules
@@ -1,4 +1,4 @@
 # Low-level USB device add trigger
 ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{ID_USB_INTERFACES}=="*:0701??:*", TAG+="systemd", ENV{SYSTEMD_WANTS}="configure-printer@usb-$env{BUSNUM}-$env{DEVNUM}.service"
 # Low-level USB device remove trigger
-ACTION=="remove", SUBSYSTEM=="usb", ENV{INTERFACE}=="7/1/*", ENV{INTERFACE}!="7/1/4", RUN+="udev-configure-printer remove %p"
+ACTION=="remove", SUBSYSTEM=="usb", ENV{INTERFACE}=="7/1/*", RUN+="udev-configure-printer remove %p"


### PR DESCRIPTION
 * Update the udev rule due to usb_id udev import is disabled in some systems.
 * Make the matching rule of printer device path more flexible.