### PR TITLE
asyncpk1.py: Import the gi module before calling gi.require_version

### DIFF
--- a/asyncpk1.py
+++ b/asyncpk1.py
@@ -22,6 +22,8 @@ import cups
 import dbus
 from functools import reduce
 try:
+    import gi
+    gi.require_version('Gdk', '3.0')
     from gi.repository import Gdk
     gi.require_version('Gtk', '3.0')
     from gi.repository import Gtk


### PR DESCRIPTION
This reverts aa6500531326c4895f70f238a75f4537fe3532db

Properly fix #179