### PR TITLE
Set username then password fields for SMB printer

### DIFF
--- a/ui/NewPrinterWindow.ui
+++ b/ui/NewPrinterWindow.ui
@@ -1054,25 +1054,6 @@ ipp://printer.mydomain/ipp</property>
                                                 <property name="halign">start</property>
                                                 <property name="column_homogeneous">True</property>
                                                 <child>
-                                                  <object class="GtkLabel" id="label133">
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
-                                                    <property name="halign">start</property>
-                                                    <property name="margin_left">12</property>
-                                                    <property name="margin_right">12</property>
-                                                    <property name="margin_top">6</property>
-                                                    <property name="margin_bottom">6</property>
-                                                    <property name="label" translatable="yes">Password:</property>
-                                                    <accessibility>
-                                                      <relation type="label-for" target="entSMBPassword"/>
-                                                    </accessibility>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="left_attach">0</property>
-                                                    <property name="top_attach">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
                                                   <object class="GtkLabel" id="label132">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
@@ -1084,6 +1065,44 @@ ipp://printer.mydomain/ipp</property>
                                                     <property name="label" translatable="yes">Username:</property>
                                                     <accessibility>
                                                       <relation type="label-for" target="entSMBUsername"/>
+                                                    </accessibility>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left_attach">0</property>
+                                                    <property name="top_attach">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkEntry" id="entSMBUsername">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="margin_left">12</property>
+                                                    <property name="margin_right">12</property>
+                                                    <property name="margin_top">6</property>
+                                                    <property name="margin_bottom">6</property>
+                                                    <property name="primary_icon_activatable">False</property>
+                                                    <property name="secondary_icon_activatable">False</property>
+                                                    <accessibility>
+                                                      <relation type="labelled-by" target="label132"/>
+                                                    </accessibility>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="left_attach">1</property>
+                                                    <property name="top_attach">0</property>
+                                                  </packing>
+                                                </child>
+                                                <child>
+                                                  <object class="GtkLabel" id="label133">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="halign">start</property>
+                                                    <property name="margin_left">12</property>
+                                                    <property name="margin_right">12</property>
+                                                    <property name="margin_top">6</property>
+                                                    <property name="margin_bottom">6</property>
+                                                    <property name="label" translatable="yes">Password:</property>
+                                                    <accessibility>
+                                                      <relation type="label-for" target="entSMBPassword"/>
                                                     </accessibility>
                                                   </object>
                                                   <packing>
@@ -1104,25 +1123,6 @@ ipp://printer.mydomain/ipp</property>
                                                     <property name="secondary_icon_activatable">False</property>
                                                     <accessibility>
                                                       <relation type="labelled-by" target="label133"/>
-                                                    </accessibility>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="left_attach">1</property>
-                                                    <property name="top_attach">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkEntry" id="entSMBUsername">
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="margin_left">12</property>
-                                                    <property name="margin_right">12</property>
-                                                    <property name="margin_top">6</property>
-                                                    <property name="margin_bottom">6</property>
-                                                    <property name="primary_icon_activatable">False</property>
-                                                    <property name="secondary_icon_activatable">False</property>
-                                                    <accessibility>
-                                                      <relation type="labelled-by" target="label132"/>
                                                     </accessibility>
                                                   </object>
                                                   <packing>


### PR DESCRIPTION
Usually for SMB authentication the username field is used first, then the password field.
This commit set this order for new SMB printer pane.