### PR TITLE
remove python3-requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Runtime requirements:
 - python3-firewall
 - python3-gobject
 - python3-pycurl
-- python3-requests
 - (optional) python3-smbc
 
 How to compile and install:

--- a/cupshelpers/openprinting.py
+++ b/cupshelpers/openprinting.py
@@ -69,7 +69,7 @@ class _QueryThread (threading.Thread):
         self.result = b''
         status = 1
         try:
-            req = urllib.request(self.url, headers=headers)
+            req = urllib.request.Request(self.url, headers=headers)
             with urllib.request.urlopen(req, timeout=HTTPS_TIMEOUT) as resp:
                 self.result = resp.read()
                 status = 0

--- a/newprinter.py
+++ b/newprinter.py
@@ -29,7 +29,7 @@ import cupshelpers
 from OpenPrintingRequest import OpenPrintingRequest
 
 import errno
-import sys, os, tempfile, time, traceback, re, http.client
+import sys, os, tempfile, time, re, http.client
 import locale
 import string
 import subprocess
@@ -37,7 +37,6 @@ from timedops import *
 import dbus
 from gi.repository import Gdk
 from gi.repository import Gtk
-import requests
 import functools
 
 import cups
@@ -68,6 +67,7 @@ import installpackage
 import gettext
 gettext.install(domain=config.PACKAGE, localedir=config.localedir)
 
+HTTPS_TIMEOUT = 15.0
 
 TEXT_adjust_firewall = _("The firewall may need adjusting in order to "
                          "detect network printers.  Adjust the "
@@ -150,39 +150,15 @@ def download_gpg_fingerprint(url):
         debugprint('Not a https fingerprint URL: %s, ignoring driver' % url)
         return None
 
-    # Possible paths of a file with a set of SSL certificates which are
-    # considered trustworthy. The first one that exists will be used.
-    # This is used for downloading GPG key fingerprints for
-    # openprinting.org driver packages.
-    ssl_cert_file_paths = [
-        # Debian/Ubuntu use the ca-certificates package:
-        '/etc/ssl/certs/ca-certificates.crt',
-
-        # Fedora place the certificates in different locations:
-        '/etc/ssl/certs/ca-bundle.crt',
-        '/etc/pki/tls/certs/ca-bundle.crt'
-        ]
-
-    # default GPG key server
-    # this is the generally recommended DNS round-robin, but usually very
-    # slow:
-    #gpg_key_server = 'keys.gnupg.net'
-    gpg_key_server = 'hkp://keyserver.ubuntu.com:80'
-
-    cert = None
-    for f in ssl_cert_file_paths:
-        if os.path.exists(f):
-            cert = f
-            break;
-
-    if not cert:
-        debugprint('No system SSL certificates available for trust checking')
-        return None
-
+    content = None
     try:
-        req = requests.get(url, verify=cert)
-        content = req.content.decode("utf-8")
+        with urllib.request.urlopen(url, timeout=HTTPS_TIMEOUT) as resp:
+            if resp.status == 200:
+                content = resp.read().decode('utf-8')
     except:
+        pass
+
+    if content is None:
         debugprint('Cannot retrieve %s' % url)
         return None
 

--- a/newprinter.py
+++ b/newprinter.py
@@ -155,8 +155,8 @@ def download_gpg_fingerprint(url):
         with urllib.request.urlopen(url, timeout=HTTPS_TIMEOUT) as resp:
             if resp.status == 200:
                 content = resp.read().decode('utf-8')
-    except:
-        pass
+    except Exception as e:
+        debugprint('Cannot retrieve %s: %s' % (url, e))
 
     if content is None:
         debugprint('Cannot retrieve %s' % url)


### PR DESCRIPTION
At this stage, this is mostly just a request for comments. I'm trying to remove python3-requests as a dependency of the Ubuntu base system. This project has been mostly successful for the server edition, since these patches made it possible to run Ubuntu 21.04 and later without python3-requests:

* https://code.launchpad.net/~slingamn/ssh-import-id/+git/ssh-import-id/+merge/389139
* https://bugs.launchpad.net/ubuntu/+source/apport/+bug/1903605
* https://code.launchpad.net/~ddstreet/software-properties/+git/software-properties/+merge/396926

For 22.04 I'd like to remove it as a dependency of the desktop system as well. I think system-config-printer is the only "core" package that still depends on it, so here's a draft of a patch that removes the dependency.

I wasn't sure how best to test these changes. The API at `https://openprinting.org/query.cgi` seems to be down or misconfigured right now?

Thanks very much for your time.