### PR TITLE
fix preserve_job_files default settings

### DIFF
--- a/serversettings.py
+++ b/serversettings.py
@@ -153,7 +153,7 @@ class ServerSettings(GtkGUI):
             raise RuntimeError
 
         preserve_job_history = True
-        preserve_job_files = False
+        preserve_job_files = True
         browsing = True
         self.browse_poll = []
         f.seek (0)
@@ -421,9 +421,9 @@ class ServerSettings(GtkGUI):
         if not preserve_job_history:
             job_history_line = "PreserveJobHistory No\n"
 
-        # Default is not to preserve job files.
-        if preserve_job_files:
-            job_files_line = "PreserveJobFiles Yes\n"
+        # Default is to preserve job files.
+        if not preserve_job_files:
+            job_files_line = "PreserveJobFiles No\n"
 
         for server in browse_poll:
             browsepoll_lines += "BrowsePoll %s\n" % server


### PR DESCRIPTION
In the manual of cupsd.conf, the default setting of PerserveJobFiles is '86400';
but in serversettings.py, the default setting of preserve_job_files is 'False'.