### PR TITLE
Support GNOME 42 dark style preference

### DIFF
--- a/system-config-printer.py
+++ b/system-config-printer.py
@@ -47,6 +47,16 @@ except RuntimeError as e:
     print ("This is a graphical application and requires DISPLAY to be set.")
     sys.exit (1)
 
+# Optional dependency, requires libhandy >= 1.5
+gi.require_version('Handy', '1')
+try:
+    from gi.repository import Handy
+    Handy.init()
+    # Support GNOME 42 dark mode
+    Handy.StyleManager.get_default().set_color_scheme(Handy.ColorScheme.PREFER_LIGHT)
+except:
+    pass
+
 def show_help():
     print ("\nThis is system-config-printer, " \
            "a CUPS server configuration program.\n\n"


### PR DESCRIPTION
Adds an optional dependency on libhandy >= 1.5

Here's a [developer blog post](https://blogs.gnome.org/alexm/2021/10/04/dark-style-preference/) about the feature.