### PR TITLE
Remove superfulous build requires from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=61.0",
-    "pycups",
-    "build",
-    "pip",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
None of the listed packages is required to build it.

pip/build invokes this, there is no need to install them into the build environment.

pycups is not used during the build.