### PR TITLE
#375 Add checkbox for sharing when adding a printer

### DIFF
--- a/ui/NewPrinterWindow.ui
+++ b/ui/NewPrinterWindow.ui
@@ -219,6 +219,36 @@
                         <property name="position">2</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkFrame" id="isSharedFrame">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
+                        <child>
+                          <object class="GtkCheckButton" id="isSharedCbx">
+                            <property name="label" translatable="yes">Use sharing</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="draw-indicator">True</property>
+                          </object>
+                        </child>
+                        <child type="label">
+                          <object class="GtkLabel" id="isSharedTitle">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">&lt;b&gt;Shared&lt;/b&gt;</property>
+                            <property name="use-markup">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">True</property>


### PR DESCRIPTION
In the printer add menu there is no checkbox or any other way to specify whether to use shared access or
not when adding a device. The device is set to the default value defined in CUPS after adding.

The patch adds a new line to the "Describe Printer" section, containing a checkbox that allows users to specify whether to use shared access or not for the device being added