### PR TITLE
Fix multi-backend handling

### DIFF
--- a/newprinter.py
+++ b/newprinter.py
@@ -3053,7 +3053,6 @@ class NewPrinterGUI(GtkGUI):
         physicaldevice = model.get_value (iter, 1)
         if physicaldevice is None:
             return
-        show_uris = True
         for device in physicaldevice.get_devices ():
             if device.type == "parallel":
                 device.menuentry = _("Parallel Port")
@@ -3137,7 +3136,6 @@ class NewPrinterGUI(GtkGUI):
                         device.menuentry = \
                             _("Network printer via DNS-SD")
             else:
-                show_uris = False
                 device.menuentry = device.uri
 
         model = Gtk.ListStore (str,                    # URI description
@@ -3234,7 +3232,7 @@ class NewPrinterGUI(GtkGUI):
             n += 1
         column = self.tvNPDeviceURIs.get_column (0)
         self.tvNPDeviceURIs.set_cursor (Gtk.TreePath(), column, False)
-        if show_uris:
+        if n > 1:
             self.expNPDeviceURIs.show_all ()
         else:
             self.expNPDeviceURIs.hide ()


### PR DESCRIPTION
It is not possible to select another backend if it is not «whitelisted».

Example. One device, multiple backends:
```sh
% lpinfo -v
direct usb://Canon/LBP3200?serial=00000000
direct captusb://Canon/LBP3200?serial=00000000

% python3 PhysicalDevice.py
Canon LBP3200 (00000000)
  <cupshelpers.Device "usb://Canon/LBP3200?serial=00000000">
  <cupshelpers.Device "captusb://Canon/LBP3200?serial=00000000">
```
The backend is defined correctly, but it is not displayed in the UI.

The reason is here:
```py
if device.type == "parallel":
    ...
elif device.type == "serial":
    ...
elif device.type == "usb":
    ...
<...>
else:
    # device.type is "captusb"
    show_uris = False
```
https://github.com/OpenPrinting/system-config-printer/blob/4ec8a945e03ddd769ab26f5e735808b5e69301fb/newprinter.py#L3140

So, if you have multiple backends for a device, any other non-standard backend will not be visible to the end user.
The backend selection list simply won't be shown.

This patch makes the selection list visible if multiple backends are available for the device.

<details>
    <summary>The selection list looks like this (with multiple backends, it's just hidden)</summary>
    <img width="790" height="730" alt="Single backend" src="https://github.com/user-attachments/assets/caf07013-be36-4e2e-8281-b81c22a86160" />
</details>

**P.S.** I just checked git blame and found that my patch literally undoes this commit: https://github.com/OpenPrinting/system-config-printer/commit/92c531cf07cfd9e416e204e6085ada242468bf97 \
Any thoughts on why it was done this way?