### PR TITLE
Fix DeprecationWarning: Removed Gdk.threads_enter/leave calls

### DIFF
--- a/asyncipp.py
+++ b/asyncipp.py
@@ -175,13 +175,11 @@ class _IPPConnectionThread(threading.Thread):
 
     def _auth (self, prompt, conn=None, method=None, resource=None):
         def prompt_auth (prompt):
-            Gdk.threads_enter ()
             if conn is None:
                 self._auth_handler (prompt, self._conn)
             else:
                 self._auth_handler (prompt, self._conn, method, resource)
 
-            Gdk.threads_leave ()
             return False
 
         if self._auth_handler is None:
@@ -194,9 +192,7 @@ class _IPPConnectionThread(threading.Thread):
     def _reply (self, result):
         def send_reply (handler, result):
             if not self._destroyed:
-                Gdk.threads_enter ()
                 handler (self._conn, result)
-                Gdk.threads_leave ()
             return False
 
         if not self._destroyed and self._reply_handler:
@@ -205,9 +201,7 @@ class _IPPConnectionThread(threading.Thread):
     def _error (self, exc):
         def send_error (handler, exc):
             if not self._destroyed:
-                Gdk.threads_enter ()
                 handler (self._conn, exc)
-                Gdk.threads_leave ()
             return False
 
         if not self._destroyed and self._error_handler:

--- a/asyncpk1.py
+++ b/asyncpk1.py
@@ -110,17 +110,9 @@ class _PK1AsyncMethodCall:
             return
 
         if str (error) == '':
-            try:
-                Gdk.threads_enter ()
-            except:
-                pass
             debugprint ("%s: no error, calling reply handler %s" %
                         (self, self._client_reply_handler))
             self._client_reply_handler (self._conn, self._unpack_fn (*args))
-            try:
-                Gdk.threads_leave ()
-            except:
-                pass
             self._destroy ()
             return
 
@@ -133,17 +125,9 @@ class _PK1AsyncMethodCall:
 
         if exc.get_dbus_name () == CUPS_PK_NEED_AUTH:
             exc = cups.IPPError (cups.IPP_NOT_AUTHORIZED, 'pkcancel')
-            try:
-                Gdk.threads_enter ()
-            except:
-                pass
             debugprint ("%s: no auth, calling error handler %s" %
                         (self, self._client_error_handler))
             self._client_error_handler (self._conn, exc)
-            try:
-                Gdk.threads_leave ()
-            except:
-                pass
             self._destroy ()
             return
 

--- a/authconn.py
+++ b/authconn.py
@@ -302,9 +302,6 @@ class Connection:
         return result
 
     def _ask_retry_server_error (self, message):
-        if self._lock:
-            Gdk.threads_enter ()
-
         try:
             msg = (_("CUPS server error (%s)") % self._operation_stack[0])
         except IndexError:
@@ -323,7 +320,6 @@ class Connection:
         d.set_default_response (Gtk.ResponseType.OK)
         if self._lock:
             d.connect ("response", self._on_retry_server_error_response)
-            Gdk.threads_leave ()
         else:
             self._retry_response = d.run ()
             d.destroy ()
@@ -449,8 +445,6 @@ class Connection:
         return 1
 
     def _show_not_authorized_dialog (self):
-        if self._lock:
-            Gdk.threads_enter ()
         d = Gtk.MessageDialog (transient_for=self._parent,
                                modal=True, destroy_with_parent=True,
                                message_type=Gtk.MessageType.ERROR,
@@ -463,7 +457,6 @@ class Connection:
             d.connect ("response", self._on_not_authorized_dialog_response)
             d.show_all ()
             d.show_now ()
-            Gdk.threads_leave ()
         else:
             d.run ()
             d.destroy ()
@@ -473,9 +466,6 @@ class Connection:
         dialog.destroy ()
 
     def _perform_authentication_with_dialog (self):
-        if self._lock:
-            Gdk.threads_enter ()
-
         # Prompt.
         if len (self._operation_stack) > 0:
             try:
@@ -497,7 +487,6 @@ class Connection:
         self._dialog_shown = True
         if self._lock:
             d.connect ("response", self._on_authentication_response)
-            Gdk.threads_leave ()
         else:
             response = d.run ()
             self._on_authentication_response (d, response)

--- a/cupshelpers/openprinting.py
+++ b/cupshelpers/openprinting.py
@@ -448,24 +448,18 @@ def _simple_gui ():
             text = ""
             for printer in printers.values ():
                 text += printer + "\n"
-            Gdk.threads_enter ()
             self.tv.get_buffer ().set_text (text)
-            Gdk.threads_leave ()
 
         def list_drivers_callback (self, status, user_data, drivers):
             if status != 0:
                 raise drivers[1]
 
             text = pprint.pformat (drivers)
-            Gdk.threads_enter ()
             self.tv.get_buffer ().set_text (text)
-            Gdk.threads_leave ()
 
         def query_callback (self, status, user_data, result):
-            Gdk.threads_enter ()
             self.tv.get_buffer ().set_text (str (result))
             open ("result.xml", "w").write (str (result))
-            Gdk.threads_leave ()
 
     q = QueryApp()
     Gtk.main ()

--- a/gtkinklevel.py
+++ b/gtkinklevel.py
@@ -116,13 +116,11 @@ if __name__ == '__main__':
     from gi.repository import GLib
     import time
     def adjust_level (level):
-        Gdk.threads_enter ()
         l = level.get_level ()
         l += 1
         if l > 100:
             l = 0
         level.set_level (l)
-        Gdk.threads_leave ()
         return True
 
     w = Gtk.Window ()

--- a/jobviewer.py
+++ b/jobviewer.py
@@ -816,9 +816,7 @@ class JobViewer (GtkGUI):
 
         if need_update and not self.job_creation_times_timer:
             def update_times_with_locking ():
-                Gdk.threads_enter ()
                 ret = self.update_job_creation_times ()
-                Gdk.threads_leave ()
                 return ret
 
             t = GLib.timeout_add_seconds (60, update_times_with_locking)
@@ -873,9 +871,7 @@ class JobViewer (GtkGUI):
 
         if not self.job_creation_times_timer:
             def start_updating_job_creation_times():
-                Gdk.threads_enter ()
                 self.update_job_creation_times ()
-                Gdk.threads_leave ()
                 return False
 
             GLib.timeout_add (500, start_updating_job_creation_times)
@@ -1797,7 +1793,6 @@ class JobViewer (GtkGUI):
             self.worst_reason = worst_reason
             debugprint ("Worst reason: %s" % worst_reason)
 
-        Gdk.threads_enter ()
         self.statusbar.pop (0)
         if self.worst_reason is not None:
             (title, tooltip) = self.worst_reason.get_description ()
@@ -1825,8 +1820,6 @@ class JobViewer (GtkGUI):
             self.statusicon.set_from_pixbuf (pixbuf)
             self.set_statusicon_visibility ()
             self.set_statusicon_tooltip (tooltip=tooltip)
-
-        Gdk.threads_leave ()
 
     ## Notifications
     def notify_printer_state_reason_if_important (self, reason):

--- a/newprinter.py
+++ b/newprinter.py
@@ -1744,15 +1744,13 @@ class NewPrinterGUI(GtkGUI):
         for handler in self.opreq_handlers:
             opreq.disconnect (handler)
 
-        Gdk.threads_enter ()
-
-        try:
             self.opreq_user_search = False
             self.opreq_handlers = None
             self.opreq = None
             self._searchdialog.hide ()
             self._searchdialog.destroy ()
             self._searchdialog = None
+
 
             # Check whether we have found something
             if len (printers) < 1:
@@ -1769,28 +1767,21 @@ class NewPrinterGUI(GtkGUI):
                 self.downloadable_drivers = drivers
                 self.founddownloadabledrivers = True
 
-                try:
-                    self.NewPrinterWindow.show()
-                    self.setNPButtons()
-                    if not self.fillDownloadableDrivers():
-                        ready (self.NewPrinterWindow)
-
-                        self.founddownloadabledrivers = False
-                        if self.dialog_mode == "download_driver":
-                            self.on_NPCancel(None)
-                        else:
-                            self.nextNPTab ()
+                self.NewPrinterWindow.show()
+                self.setNPButtons()
+                    
+                if not self.fillDownloadableDrivers():
+                    ready(self.NewPrinterWindow)
+                    self.founddownloadabledrivers = False
+                    if self.dialog_mode == "download_driver":
+                        self.on_NPCancel(None)
                     else:
-                        if self.dialog_mode == "download_driver":
-                            self.nextNPTab (step = 0)
-                        else:
-                            self.nextNPTab ()
-                except:
-                    nonfatalException ()
-                    self.nextNPTab ()
-
-        finally:
-            Gdk.threads_leave ()
+                        self.nextNPTab()
+                else:
+                    if self.dialog_mode == "download_driver":
+                        self.nextNPTab(step=0)
+                    else:
+                        self.nextNPTab()
 
     def opreq_id_search_error (self, opreq, status, err):
         debugprint ("OpenPrinting request failed (%d): %s" % (status,
@@ -3488,7 +3479,6 @@ class NewPrinterGUI(GtkGUI):
         self.printer_finder = finder
 
     def found_network_printer_callback (self, new_device):
-        Gdk.threads_enter ()
         if new_device:
             self.network_found += 1
             dev = PhysicalDevice (new_device)
@@ -3530,7 +3520,6 @@ class NewPrinterGUI(GtkGUI):
                                                           "address.") + '</i>')
                 self.lblNetworkFindNotFound.show ()
 
-        Gdk.threads_leave ()
     ###
 
     def getDeviceURI(self):
@@ -3674,7 +3663,6 @@ class NewPrinterGUI(GtkGUI):
 
         button = self.btnNPDownloadableDriverSearch
         label = self.btnNPDownloadableDriverSearch_label
-        Gdk.threads_enter ()
         try:
             label.set_text (_("Search"))
             button.set_sensitive (True)
@@ -3709,8 +3697,6 @@ class NewPrinterGUI(GtkGUI):
             self.setNPButtons ()
         except:
             nonfatalException()
-
-        Gdk.threads_leave ()
 
     def opreq_user_search_error (self, opreq, status, err):
         debugprint ("OpenPrinting request failed (%d): %s" % (status,

--- a/ppdcache.py
+++ b/ppdcache.py
@@ -175,9 +175,7 @@ class PPDCache:
 
     def _schedule_callback (self, callback, name, result, exc):
         def cb_func (callback, name, result, exc):
-            Gdk.threads_enter ()
             callback (name, result, exc)
-            Gdk.threads_leave ()
             return False
 
         GLib.idle_add (cb_func, callback, name, result, exc)

--- a/probe_printer.py
+++ b/probe_printer.py
@@ -207,9 +207,7 @@ class BackgroundSmbAuthContext(pysmb.AuthContext):
         pysmb.AuthContext.__init__ (self, *args, **kwargs)
 
     def _do_perform_authentication (self):
-        Gdk.threads_enter ()
         result = pysmb.AuthContext.perform_authentication (self)
-        Gdk.threads_leave ()
         self._do_perform_authentication_result = result
         self._gui_event.set ()
         

--- a/scp-dbus-service.py
+++ b/scp-dbus-service.py
@@ -429,11 +429,9 @@ class ConfigPrintingJobApplet(dbus.service.Object):
     def __init__ (self, bus, path):
         bus_name = dbus.service.BusName (CONFIG_BUS, bus=bus)
         dbus.service.Object.__init__ (self, bus_name=bus_name, object_path=path)
-        Gdk.threads_enter ()
         self.jobapplet = jobviewer.JobViewer(bus=dbus.SystemBus (),
                                              applet=True, my_jobs=True)
         self.jobapplet.set_process_pending (False)
-        Gdk.threads_leave ()
         handle = self.jobapplet.connect ('finished', self.on_jobapplet_finished)
         self.finished_handle = handle
         self.has_finished = False
@@ -599,7 +597,5 @@ if __name__ == '__main__':
     debugprint ("Service running...")
     g_killtimer = killtimer.KillTimer (killfunc=Gtk.main_quit)
     cp = ConfigPrinting ()
-    Gdk.threads_enter ()
     Gtk.main ()
-    Gdk.threads_leave ()
     cp.destroy ()

--- a/system-config-printer.py
+++ b/system-config-printer.py
@@ -1200,15 +1200,10 @@ class GUI(GtkGUI):
 
     def update_connecting_pbar (self):
         ret = True
-        Gdk.threads_enter ()
-        try:
-            if not self.ConnectingDialog.get_property ("visible"):
-                ret = False # stop animation
-            else:
-                self.pbarConnecting.pulse ()
-        finally:
-            Gdk.threads_leave ()
-
+        if not self.ConnectingDialog.get_property ("visible"):
+            ret = False # stop animation
+        else:
+            self.pbarConnecting.pulse ()
         return ret
 
     def on_connectingdialog_delete (self, widget, event):
@@ -1254,34 +1249,25 @@ class GUI(GtkGUI):
                                              encryption=self.connect_encrypt)
         except RuntimeError as s:
             if self.connect_thread != _thread.get_ident(): return
-            Gdk.threads_enter()
-            try:
-                self.ConnectingDialog.hide()
-                self.cups = None
-                self.setConnected()
-                self.populateList()
-                show_IPP_Error(None, s, parent)
-            finally:
-                Gdk.threads_leave()
+            self.ConnectingDialog.hide()
+            self.cups = None
+            self.setConnected()
+            self.populateList()
+            show_IPP_Error(None, s, parent)
             return
         except cups.IPPError as e:
             (e, s) = e.args
             if self.connect_thread != _thread.get_ident(): return
-            Gdk.threads_enter()
-            try:
-                self.ConnectingDialog.hide()
-                self.cups = None
-                self.setConnected()
-                self.populateList()
-                show_IPP_Error(e, s, parent)
-            finally:
-                Gdk.threads_leave()
+            self.ConnectingDialog.hide()
+            self.cups = None
+            self.setConnected()
+            self.populateList()
+            show_IPP_Error(e, s, parent)
             return
         except:
             nonfatalException ()
 
         if self.connect_thread != _thread.get_ident(): return
-        Gdk.threads_enter()
 
         try:
             self.ConnectingDialog.hide()
@@ -1296,8 +1282,6 @@ class GUI(GtkGUI):
             show_HTTP_Error(s, parent)
         except:
             nonfatalException ()
-
-        Gdk.threads_leave()
 
     def reconnect (self):
         """Reconnect to CUPS after the server has reloaded."""
@@ -2075,24 +2059,15 @@ class GUI(GtkGUI):
         GLib.timeout_add_seconds (1, self.service_started_try)
 
     def service_started_try (self):
-        Gdk.threads_enter ()
-        try:
-            self.on_btnRefresh_clicked (None)
-        finally:
-            Gdk.threads_leave ()
+        self.on_btnRefresh_clicked (None)
 
         GLib.timeout_add_seconds (1, self.service_started_retry)
         return False
 
     def service_started_retry (self):
         if not self.cups:
-            Gdk.threads_enter ()
-            try:
-                self.on_btnRefresh_clicked (None)
-                self.btnStartService.set_sensitive (True)
-            finally:
-                Gdk.threads_leave ()
-
+            self.on_btnRefresh_clicked (None)
+            self.btnStartService.set_sensitive (True)
         return False
 
     def checkDriverExists(self, parent, name, ppd=None):
@@ -2197,11 +2172,7 @@ class GUI(GtkGUI):
     def defer_refresh (self):
         def deferred_refresh ():
             self.populateList_timer = None
-            Gdk.threads_enter ()
-            try:
-                self.populateList (prompt_allowed=False)
-            finally:
-                Gdk.threads_leave ()
+            self.populateList (prompt_allowed=False)
             return False
 
         if self.populateList_timer:
@@ -2250,11 +2221,7 @@ def main(show_jobs):
     else:
         mainwindow = GUI()
 
-    Gdk.threads_enter ()
-    try:
-        Gtk.main()
-    finally:
-        Gdk.threads_leave ()
+    Gtk.main()
 
 if __name__ == "__main__":
     import getopt

--- a/timedops.py
+++ b/timedops.py
@@ -108,7 +108,6 @@ class TimedSubprocess(Timed):
         return True
 
     def show_wait_window (self):
-        Gdk.threads_enter ()
         wait = Gtk.MessageDialog (parent=self.parent,
                                   modal=True, destroy_with_parent=True,
                                   message_type=Gtk.MessageType.INFO,
@@ -122,7 +121,6 @@ class TimedSubprocess(Timed):
         wait.format_secondary_text (_("Gathering information"))
         wait.show_all ()
         self.wait_window = wait
-        Gdk.threads_leave ()
         return False
 
     def wait_window_response (self, dialog, response):

--- a/troubleshoot/PrintTestPage.py
+++ b/troubleshoot/PrintTestPage.py
@@ -476,7 +476,6 @@ class PrintTestPage(Question):
 
         # Enter the GDK lock.  We need to do this because we were
         # called from a timeout.
-        Gdk.threads_enter ()
 
         parent = self.troubleshooter.get_window ()
         self.op = TimedOperation (get_notifications,
@@ -485,7 +484,6 @@ class PrintTestPage(Question):
         try:
             notifications = self.op.run ()
         except (OperationCanceled, cups.IPPError):
-            Gdk.threads_leave ()
             return True
 
         answers = self.troubleshooter.answers
@@ -527,5 +525,4 @@ class PrintTestPage(Question):
             self.update_jobs_list)
         debugprint ("Update again in %ds" %
                     notifications['notify-get-interval'])
-        Gdk.threads_leave ()
         return False

--- a/troubleshoot/__init__.py
+++ b/troubleshoot/__init__.py
@@ -381,6 +381,4 @@ if __name__ == "__main__":
         pass
     Gdk.threads_init()
     run (Gtk.main_quit)
-    Gdk.threads_enter ()
     Gtk.main ()
-    Gdk.threads_leave ()


### PR DESCRIPTION
Removes the deprecated Gdk.threads_enter() and Gdk.threads_leave() calls.
Modern Gdk handles thread locking automatically, so these manual locks are no longer needed and cause DeprecationWarnings.

Tested locally on Fedora; the application launches correctly and the specific DeprecationWarning is gone.

Closes #126