### PR TITLE
system-config-printer.desktop.in: add Keywords

### DIFF
--- a/system-config-printer.desktop.in
+++ b/system-config-printer.desktop.in
@@ -3,6 +3,7 @@ Name=Print Settings
 GenericName=Print Settings
 X-GNOME-FullName=Print Settings
 Comment=Configure printers
+Keywords=system-config-printer;printer;config;
 Exec=system-config-printer
 Terminal=false
 Type=Application


### PR DESCRIPTION
Add 'system-config-printer', 'printer' and 'config' to .desktop Keywords.

So that the program can be found by the name of the program, since 'Exec' field does not match the name in the 'Name' field.