### PR TITLE
Fix invalid trove classifier in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = { file = "COPYING" }
 readme = "README.md"
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: GPL 2 or later",
+  "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
   "Operating System :: Linux",
 ]
 requires-python = ">=3.7"


### PR DESCRIPTION
Use the canonical "GNU General Public License v2 or later (GPLv2+)" instead of the non-standard "GPL 2 or later", which fails setuptools validation during build.

Search at https://codesearch.debian.net/ showed that nobody uses the old variant.
