### PR TITLE
Fix invalid trove classifiers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ license = { file = "COPYING" }
 readme = "README.md"
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: GPL 2 or later",
-  "Operating System :: Linux",
+  "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
+  "Operating System :: POSIX :: Linux",
 ]
 requires-python = ">=3.7"
 


### PR DESCRIPTION
Use canonical trove classifiers that pass setuptools validation:

- "GNU General Public License v2 or later (GPLv2+)" instead of "GPL 2 or later"
- "Operating System :: POSIX :: Linux" instead of "Operating System :: Linux"

Search at https://codesearch.debian.net/ showed that old variants are not used.
