### PR TITLE
Added special processing for the string "Canon Inc"

### DIFF
--- a/cupshelpers/ppds.py
+++ b/cupshelpers/ppds.py
@@ -161,6 +161,9 @@ def ppdMakeModelSplit (ppd_make_and_model):
         cleanup_make = True
 
     # Special handling for two-word manufacturers
+    elif l.startswith ("canon inc "):
+        make = "Canon"
+        model = ppd_make_and_model[10:]
     elif l.startswith ("konica minolta "):
         make = "KONICA MINOLTA"
         model = ppd_make_and_model[15:]


### PR DESCRIPTION
Canon's IEEE 1284 Device ID printer gives MFG:Canon, and in some PPDs there is a line "Canon Inc"
For this reason, the automatic search for the desired PPD does not work when the printer is connected.