### PR TITLE
cupshelpers: let PPDs with a blank MFG match their device

### DIFF
--- a/cupshelpers/ppds.py
+++ b/cupshelpers/ppds.py
@@ -1157,12 +1157,9 @@ class PPDs:
             lmfg = id_dict['MFG'].lower ()
             lmdl = id_dict['MDL'].lower ()
 
-            bad = False
-            if len (lmfg) == 0:
-                bad = True
+            # A blank MFG is legal (some devices report one); index the
+            # PPD under the empty make so blank-MFG device IDs can match.
             if len (lmdl) == 0:
-                bad = True
-            if bad:
                 continue
 
             if lmfg not in ids:

--- a/cupshelpers/ppds.py
+++ b/cupshelpers/ppds.py
@@ -577,6 +577,10 @@ class PPDs:
         mfgl = mfg.lower ()
         mdll = mdl.lower ()
 
+        if mfgl == "":
+            _debugprint ("**** Device ID has an empty MFG field; "
+                         "matching on MDL alone")
+
         id_matched = False
         try:
             for each in self.ids[mfgl][mdll]:
@@ -1148,6 +1152,7 @@ class PPDs:
             return
 
         ids = {}
+        blank_mfg = 0
         for ppdname, ppddict in self.ppds.items ():
             id = _singleton (ppddict.get ('ppd-device-id'))
             if not id:
@@ -1162,6 +1167,9 @@ class PPDs:
             if len (lmdl) == 0:
                 continue
 
+            if len (lmfg) == 0:
+                blank_mfg += 1
+
             if lmfg not in ids:
                 ids[lmfg] = {}
 
@@ -1170,6 +1178,9 @@ class PPDs:
 
             ids[lmfg][lmdl].append (ppdname)
 
+        if blank_mfg:
+            _debugprint ("%d PPDs with empty MFG in their device ID, "
+                         "indexed under the empty make" % blank_mfg)
         self.ids = ids
 
 def _show_help():


### PR DESCRIPTION
Fixes #445.

`_init_ids()` drops every PPD whose device ID has an empty MFG, while
`getPPDNamesFromDeviceID()` looks the device's (also empty) MFG up in
that same table, so a printer reporting a blank MFG can never match its
PPD - it ends up on textonly.ppd. This indexes such PPDs under the empty
make instead; a non-empty MDL is still required.

Tested on Fedora 45 with a Phomemo PM-241-BT
(`MFG: ;CMD:XPP,XL;MDL:PM-241-BT;...`): with the patch,
system-config-printer, KDE printer settings and GetBestDrivers all pick
the right PPD with fit `exact-cmd`.

Assisted-by: Claude:claude-fable-5 [Claude Code]