### PR TITLE
Display IPP-over-USB printers with locally connected devices

### DIFF
--- a/dnssdresolve.py
+++ b/dnssdresolve.py
@@ -81,8 +81,11 @@ def _device_serial (device):
 
 def is_ipp_over_usb_device (device):
     parsed = urllib.parse.urlparse (device.uri)
-    return (parsed.scheme in ('ipp', 'ipps') and
-            _service_tuple_from_uri (device.uri) is not None)
+    if parsed.scheme not in ('ipp', 'ipps'):
+        return False
+    if _service_tuple_from_uri (device.uri) is None:
+        return False
+    return getattr(device, 'address', '') in ('127.0.0.1', '::1')
 
 
 def _is_legacy_usb_device (device):

--- a/newprinter.py
+++ b/newprinter.py
@@ -475,7 +475,7 @@ class NewPrinterGUI(GtkGUI):
             self._searching_spinner = Gtk.Spinner ()
             self._searching_spinner.set_halign (Gtk.Align.CENTER)
             self._searching_spinner.set_valign (Gtk.Align.CENTER)
-            self._searching_spinner.set_size_request (48, 48)
+            self._searching_spinner.set_size_request (32, 32)
             self._searching_overlay.add_overlay (self._searching_spinner)
             self._searching_overlay.show_all ()
             self._searching_spinner.hide ()

--- a/newprinter.py
+++ b/newprinter.py
@@ -2483,6 +2483,8 @@ class NewPrinterGUI(GtkGUI):
                 continue
             devs = device.get_devices ()
             network = devs[0].device_class == 'network'
+            if network and dnssdresolve.is_ipp_over_usb_device(devs[0]):
+                network = False
             info = device.get_info ()
             if device == current_device:
                 info += _(" (Current)")
@@ -2492,7 +2494,7 @@ class NewPrinterGUI(GtkGUI):
                     # An actual network printer device.  Put this at the top.
                     iter = model.insert_before (network_iter, find_nw_iter,
                                                 row=row)
-                    if device == current_device or dnssdresolve.is_ipp_over_usb_device(devs[0]):
+                    if device == current_device:
                         network_path = model.get_path(network_iter)
                         child_path = model.get_path(iter)
                         self.tvNPDevices.expand_row(network_path, False)
@@ -2520,7 +2522,7 @@ class NewPrinterGUI(GtkGUI):
 
                 iter = model.insert_before (None, iter, row=row)
 
-            if device == current_device:
+            if device == current_device or dnssdresolve.is_ipp_over_usb_device(devs[0]):
                 device_select_path = model.get_path (iter)
                 self.tvNPDevices.scroll_to_cell (device_select_path,
                                                  row_align=0.5)

--- a/newprinter.py
+++ b/newprinter.py
@@ -475,7 +475,7 @@ class NewPrinterGUI(GtkGUI):
             self._searching_spinner = Gtk.Spinner ()
             self._searching_spinner.set_halign (Gtk.Align.CENTER)
             self._searching_spinner.set_valign (Gtk.Align.CENTER)
-            self._searching_spinner.set_size_request (32, 32)
+            self._searching_spinner.set_size_request (48, 48)
             self._searching_overlay.add_overlay (self._searching_spinner)
             self._searching_overlay.show_all ()
             self._searching_spinner.hide ()

--- a/newprinter.py
+++ b/newprinter.py
@@ -2031,6 +2031,19 @@ class NewPrinterGUI(GtkGUI):
             pending = self._pending_devices
             self._pending_devices = None
             self.add_devices (pending, None, no_more=True)
+        else:
+            if hasattr(self, '_searching_row_ref') and self._searching_row_ref is not None:
+                if self._searching_row_ref.valid():
+                    model = self.tvNPDevices.get_model()
+                    if model is not None:
+                        path = self._searching_row_ref.get_path()
+                        if path is not None:
+                            try:
+                                iter = model.get_iter(path)
+                                model.remove(iter)
+                            except ValueError:
+                                pass
+                self._searching_row_ref = None
 
     def local_devices_reply (self, conn, result, current_uri):
         self.dec_spinner_task ()
@@ -2348,11 +2361,31 @@ class NewPrinterGUI(GtkGUI):
         self.fetchDevices (network=True)
 
     def start_fetching_devices (self):
+        # Insert a transient status row
+        model = self.tvNPDevices.get_model()
+        if model is not None:
+            iter = model.append(None, row=[_("Searching for printers..."), None, False])
+            path = model.get_path(iter)
+            self._searching_row_ref = Gtk.TreeRowReference.new(model, path)
+
         self.fetchDevices_conn = asyncconn.Connection ()
         self.fetchDevices_conn._begin_operation (_("fetching device list"))
         self.fetchDevices (network=False, current_uri=self.current_uri)
         del self.current_uri
     def add_devices (self, devices, current_uri, no_more=False):
+        if no_more and hasattr(self, '_searching_row_ref') and self._searching_row_ref is not None:
+            if self._searching_row_ref.valid():
+                model = self.tvNPDevices.get_model()
+                if model is not None:
+                    path = self._searching_row_ref.get_path()
+                    if path is not None:
+                        try:
+                            iter = model.get_iter(path)
+                            model.remove(iter)
+                        except ValueError:
+                            pass
+            self._searching_row_ref = None
+
         current_from_batch = False
         if current_uri:
             if current_uri in devices:

--- a/newprinter.py
+++ b/newprinter.py
@@ -198,8 +198,6 @@ class NewPrinterGUI(GtkGUI):
     INSTALL_RESULT_DONE = True
     INSTALL_RESULT_OPS_PENDING = False
 
-    SEARCHING_ROW_MINIMUM_TIME = 0.5
-
     new_printer_device_tabs = {
         "parallel" : 0, # empty tab
         "usb" : 0,
@@ -463,6 +461,26 @@ class NewPrinterGUI(GtkGUI):
         self.tvNPDevices.set_row_separator_func (self.device_row_separator_fn, None)
         self.tvNPDevices.connect ("row-activated", self.device_row_activated)
         self.tvNPDevices.connect ("row-expanded", self.device_row_expanded)
+
+        # inline searching spinner
+        scrolled = self.tvNPDevices.get_parent ()
+        parent_box = scrolled.get_parent ()
+        if parent_box is not None:
+            self._searching_overlay = Gtk.Overlay ()
+            parent_box.remove (scrolled)
+            self._searching_overlay.add (scrolled)
+            parent_box.pack_start (self._searching_overlay, True, True, 0)
+            parent_box.reorder_child (self._searching_overlay, 0)
+
+            self._searching_spinner = Gtk.Spinner ()
+            self._searching_spinner.set_halign (Gtk.Align.CENTER)
+            self._searching_spinner.set_valign (Gtk.Align.CENTER)
+            self._searching_spinner.set_size_request (32, 32)
+            self._searching_overlay.add_overlay (self._searching_spinner)
+            self._searching_overlay.show_all ()
+            self._searching_spinner.hide ()
+        else:
+            self._searching_spinner = None
 
         # Devices expander
         self.expNPDeviceURIs.connect ("notify::expanded",
@@ -1998,7 +2016,6 @@ class NewPrinterGUI(GtkGUI):
 
     def fetchDevices(self, network=False, current_uri=None):
         debugprint ("fetchDevices")
-        self.inc_spinner_task ()
 
         # Search for Bluetooth printers together with the network printers
         # as the Bluetooth search takes rather long time
@@ -2024,7 +2041,6 @@ class NewPrinterGUI(GtkGUI):
     def error_getting_devices (self, conn, exc):
         # Just ignore the error.
         debugprint ("Error fetching devices: %s" % repr (exc))
-        self.dec_spinner_task ()
         self.fetchDevices_conn._end_operation ()
         self.fetchDevices_conn.destroy ()
         self.fetchDevices_conn = None
@@ -2034,11 +2050,9 @@ class NewPrinterGUI(GtkGUI):
             self._pending_devices = None
             self.add_devices (pending, None, no_more=True)
         else:
-            self._finish_searching_row ()
+            self._hide_searching_spinner ()
 
     def local_devices_reply (self, conn, result, current_uri):
-        self.dec_spinner_task ()
-
         # Buffer local devices rather than displaying them immediately.
         # This prevents the UI from flickering when a legacy USB device
         # is briefly shown and then later suppressed/replaced by its
@@ -2071,7 +2085,6 @@ class NewPrinterGUI(GtkGUI):
         if len (need_resolving) > 0:
             # DNS-SD resolution required — keep buffering.
             resolver = dnssdresolve.DNSSDHostNamesResolver (need_resolving)
-            self.inc_spinner_task ()
             resolver.resolve (reply_handler=lambda devices:
                                   self.dnssd_resolve_reply (current_uri,
                                                             devices))
@@ -2081,7 +2094,6 @@ class NewPrinterGUI(GtkGUI):
             self._pending_devices = None
             self.add_devices (pending, current_uri, no_more=True)
 
-        self.dec_spinner_task ()
         self.check_firewall ()
 
     def dnssd_resolve_reply (self, current_uri, devices):
@@ -2095,7 +2107,6 @@ class NewPrinterGUI(GtkGUI):
         self._pending_devices = None
         self.add_devices (pending, current_uri, no_more=True)
 
-        self.dec_spinner_task ()
         self.check_firewall ()
 
     def get_hpfax_device_id(self, faxuri):
@@ -2347,73 +2358,32 @@ class NewPrinterGUI(GtkGUI):
             self.firewall.write ()
 
         debugprint ("Fetching network devices after firewall dialog response")
+        self._show_searching_spinner ()
         self.fetchDevices_conn = asyncconn.Connection ()
         self.fetchDevices_conn._begin_operation (_("fetching device list"))
         self.fetchDevices (network=True)
 
     def start_fetching_devices (self):
-        timeout_id = getattr (self, '_searching_row_timeout_id', None)
-        if timeout_id is not None:
-            GLib.source_remove (timeout_id)
-            self._searching_row_timeout_id = None
-
-        if getattr (self, '_searching_row_ref', None) is not None:
-            self._remove_searching_row ()
-
-        # Insert a transient status row
-        model = self.tvNPDevices.get_model()
-        if model is not None:
-            iter = model.append(None, row=[_("Searching for printers..."), None, False])
-            path = model.get_path(iter)
-            self._searching_row_ref = Gtk.TreeRowReference.new(model, path)
-            self._searching_row_displayed_at = time.monotonic ()
+        self._show_searching_spinner ()
 
         self.fetchDevices_conn = asyncconn.Connection ()
         self.fetchDevices_conn._begin_operation (_("fetching device list"))
         self.fetchDevices (network=False, current_uri=self.current_uri)
         del self.current_uri
 
-    def _remove_searching_row (self):
-        self._searching_row_timeout_id = None
-        row_ref = getattr (self, '_searching_row_ref', None)
-        self._searching_row_ref = None
-        self._searching_row_displayed_at = None
+    def _show_searching_spinner (self):
+        if self._searching_spinner is not None:
+            self._searching_spinner.start ()
+            self._searching_spinner.show ()
 
-        if row_ref is None or not row_ref.valid ():
-            return False
-
-        model = row_ref.get_model ()
-        path = row_ref.get_path ()
-        if model is not None and path is not None:
-            try:
-                iter = model.get_iter (path)
-                model.remove (iter)
-            except ValueError:
-                pass
-
-        return False
-
-    def _finish_searching_row (self):
-        if getattr (self, '_searching_row_ref', None) is None:
-            return
-
-        displayed_at = getattr (self, '_searching_row_displayed_at', None)
-        if displayed_at is None:
-            self._remove_searching_row ()
-            return
-
-        remaining = (self.SEARCHING_ROW_MINIMUM_TIME -
-                     (time.monotonic () - displayed_at))
-        if remaining <= 0:
-            self._remove_searching_row ()
-        elif getattr (self, '_searching_row_timeout_id', None) is None:
-            timeout = max (1, int (remaining * 1000) + 1)
-            self._searching_row_timeout_id = GLib.timeout_add (
-                timeout, self._remove_searching_row)
+    def _hide_searching_spinner (self):
+        if self._searching_spinner is not None:
+            self._searching_spinner.hide ()
+            self._searching_spinner.stop ()
 
     def add_devices (self, devices, current_uri, no_more=False):
         if no_more:
-            self._finish_searching_row ()
+            self._hide_searching_spinner ()
 
         current_from_batch = False
         if current_uri:

--- a/newprinter.py
+++ b/newprinter.py
@@ -198,6 +198,8 @@ class NewPrinterGUI(GtkGUI):
     INSTALL_RESULT_DONE = True
     INSTALL_RESULT_OPS_PENDING = False
 
+    SEARCHING_ROW_MINIMUM_TIME = 0.5
+
     new_printer_device_tabs = {
         "parallel" : 0, # empty tab
         "usb" : 0,
@@ -2032,18 +2034,7 @@ class NewPrinterGUI(GtkGUI):
             self._pending_devices = None
             self.add_devices (pending, None, no_more=True)
         else:
-            if hasattr(self, '_searching_row_ref') and self._searching_row_ref is not None:
-                if self._searching_row_ref.valid():
-                    model = self.tvNPDevices.get_model()
-                    if model is not None:
-                        path = self._searching_row_ref.get_path()
-                        if path is not None:
-                            try:
-                                iter = model.get_iter(path)
-                                model.remove(iter)
-                            except ValueError:
-                                pass
-                self._searching_row_ref = None
+            self._finish_searching_row ()
 
     def local_devices_reply (self, conn, result, current_uri):
         self.dec_spinner_task ()
@@ -2361,30 +2352,68 @@ class NewPrinterGUI(GtkGUI):
         self.fetchDevices (network=True)
 
     def start_fetching_devices (self):
+        timeout_id = getattr (self, '_searching_row_timeout_id', None)
+        if timeout_id is not None:
+            GLib.source_remove (timeout_id)
+            self._searching_row_timeout_id = None
+
+        if getattr (self, '_searching_row_ref', None) is not None:
+            self._remove_searching_row ()
+
         # Insert a transient status row
         model = self.tvNPDevices.get_model()
         if model is not None:
             iter = model.append(None, row=[_("Searching for printers..."), None, False])
             path = model.get_path(iter)
             self._searching_row_ref = Gtk.TreeRowReference.new(model, path)
+            self._searching_row_displayed_at = time.monotonic ()
 
         self.fetchDevices_conn = asyncconn.Connection ()
         self.fetchDevices_conn._begin_operation (_("fetching device list"))
         self.fetchDevices (network=False, current_uri=self.current_uri)
         del self.current_uri
+
+    def _remove_searching_row (self):
+        self._searching_row_timeout_id = None
+        row_ref = getattr (self, '_searching_row_ref', None)
+        self._searching_row_ref = None
+        self._searching_row_displayed_at = None
+
+        if row_ref is None or not row_ref.valid ():
+            return False
+
+        model = row_ref.get_model ()
+        path = row_ref.get_path ()
+        if model is not None and path is not None:
+            try:
+                iter = model.get_iter (path)
+                model.remove (iter)
+            except ValueError:
+                pass
+
+        return False
+
+    def _finish_searching_row (self):
+        if getattr (self, '_searching_row_ref', None) is None:
+            return
+
+        displayed_at = getattr (self, '_searching_row_displayed_at', None)
+        if displayed_at is None:
+            self._remove_searching_row ()
+            return
+
+        remaining = (self.SEARCHING_ROW_MINIMUM_TIME -
+                     (time.monotonic () - displayed_at))
+        if remaining <= 0:
+            self._remove_searching_row ()
+        elif getattr (self, '_searching_row_timeout_id', None) is None:
+            timeout = max (1, int (remaining * 1000) + 1)
+            self._searching_row_timeout_id = GLib.timeout_add (
+                timeout, self._remove_searching_row)
+
     def add_devices (self, devices, current_uri, no_more=False):
-        if no_more and hasattr(self, '_searching_row_ref') and self._searching_row_ref is not None:
-            if self._searching_row_ref.valid():
-                model = self.tvNPDevices.get_model()
-                if model is not None:
-                    path = self._searching_row_ref.get_path()
-                    if path is not None:
-                        try:
-                            iter = model.get_iter(path)
-                            model.remove(iter)
-                        except ValueError:
-                            pass
-            self._searching_row_ref = None
+        if no_more:
+            self._finish_searching_row ()
 
         current_from_batch = False
         if current_uri:

--- a/system-config-printer.py
+++ b/system-config-printer.py
@@ -536,12 +536,31 @@ class GUI(GtkGUI):
 
         self.setConnected()
 
-        if len (self.printers) > 4:
-            self.PrintersWindow.set_default_size (720, 345)
-        elif len (self.printers) > 2:
-            self.PrintersWindow.set_default_size (500, 345)
-        elif len (self.printers) > 1:
-            self.PrintersWindow.set_default_size (500, 180)
+
+        MIN_W, MIN_H = 720, 480
+        MAX_W, MAX_H = 1280, 900
+        FRACTION = 0.6
+
+        work_w = work_h = 0
+        screen = Gdk.Screen.get_default ()
+        if screen is not None:
+            if hasattr (screen, 'get_monitor_workarea'):
+
+                n = screen.get_primary_monitor ()
+                workarea = screen.get_monitor_workarea (n)
+                work_w = workarea.width
+                work_h = workarea.height
+            else:
+                work_w = screen.get_width ()
+                work_h = screen.get_height ()
+
+        if work_w > 0 and work_h > 0:
+            target_w = max (MIN_W, min (int (work_w * FRACTION), MAX_W))
+            target_h = max (MIN_H, min (int (work_h * FRACTION), MAX_H))
+        else:
+            target_w, target_h = MIN_W, MIN_H
+
+        self.PrintersWindow.set_default_size (target_w, target_h)
 
 
         self.PrintersWindow.show()

--- a/test_dnssdresolve.py
+++ b/test_dnssdresolve.py
@@ -27,11 +27,12 @@ def test_dns_sd_usb_ser_populates_sn():
 
 
 class DummyIPPUSBDevice:
-    def __init__(self, uri, device_class, serial):
+    def __init__(self, uri, device_class, serial, address='127.0.0.1'):
         self.uri = uri
         self.device_class = device_class
         self.type = uri.split(':', 1)[0]
         self.id_dict = {'SN': serial}
+        self.address = address
 
 
 def test_ipp_usb_helper_suppresses_legacy_usb_when_serial_matches():
@@ -67,7 +68,7 @@ def test_ipp_usb_helper_leaves_lan_ipp_unchanged():
         DummyIPPUSBDevice('usb://Xerox/B235%20MFP?serial=34004H030206H&interface=1',
                           'direct', '34004H030206H'),
         DummyIPPUSBDevice('ipp://printer.example.com/ipp/print',
-                          'network', '34004H030206H'),
+                          'network', '34004H030206H', address='192.168.1.10'),
     ]
 
     filtered = dnssdresolve.suppress_legacy_usb_devices(devices)
@@ -143,7 +144,7 @@ def test_ipp_usb_cache_does_not_affect_lan_ipp():
     usb = DummyIPPUSBDevice('usb://Xerox/B235%20MFP?serial=34004H030206H&interface=1',
                             'direct', '34004H030206H')
     ipp_lan = DummyIPPUSBDevice('ipp://printer.example.com/ipp/print',
-                                'network', '34004H030206H')
+                                'network', '34004H030206H', address='192.168.1.10')
 
     visible = dnssdresolve.suppress_legacy_usb_devices([usb], cache)
     superseded = cache.superseded_usb_serials([ipp_lan])
@@ -172,3 +173,23 @@ def test_ipp_usb_cache_does_not_suppress_usb_without_serial():
         'usb://Xerox/B235%20MFP?serial=&interface=1',
         'ipp://Xerox(R)%20B235%20MFP%20(USB)._ipp._tcp.local/',
     ]
+
+
+def test_is_ipp_over_usb_device_127_0_0_1():
+    dev = DummyIPPUSBDevice('ipp://printer._ipp._tcp.local/', 'network', '', address='127.0.0.1')
+    assert dnssdresolve.is_ipp_over_usb_device(dev) is True
+
+
+def test_is_ipp_over_usb_device_ipv6_loopback():
+    dev = DummyIPPUSBDevice('ipp://printer._ipp._tcp.local/', 'network', '', address='::1')
+    assert dnssdresolve.is_ipp_over_usb_device(dev) is True
+
+
+def test_is_ipp_over_usb_device_lan_ip():
+    dev = DummyIPPUSBDevice('ipp://printer._ipp._tcp.local/', 'network', '', address='192.168.1.10')
+    assert dnssdresolve.is_ipp_over_usb_device(dev) is False
+
+
+def test_is_ipp_over_usb_device_non_ipp_uri():
+    dev = DummyIPPUSBDevice('socket://printer._printer._tcp.local/', 'network', '', address='127.0.0.1')
+    assert dnssdresolve.is_ipp_over_usb_device(dev) is False

--- a/ui/NewPrinterWindow.ui
+++ b/ui/NewPrinterWindow.ui
@@ -3336,10 +3336,12 @@ ipp://printer.mydomain/ipp</property>
             <child>
               <object class="GtkSpinner" id="spinner">
                 <property name="can_focus">False</property>
+                <property name="width_request">44</property>
+                <property name="height_request">44</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">True</property>
+                <property name="fill">False</property>
                 <property name="position">0</property>
               </packing>
             </child>

--- a/ui/NewPrinterWindow.ui
+++ b/ui/NewPrinterWindow.ui
@@ -3336,12 +3336,10 @@ ipp://printer.mydomain/ipp</property>
             <child>
               <object class="GtkSpinner" id="spinner">
                 <property name="can_focus">False</property>
-                <property name="width_request">44</property>
-                <property name="height_request">44</property>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>


### PR DESCRIPTION
## Description

IPP-over-USB printers discovered through DNS-SD can currently be classified as
network printers in the New Printer dialog.

This change identifies IPP-over-USB devices using their DNS-SD IPP URI together
with their loopback address, while keeping normal LAN IPP printers classified
as network printers.

The New Printer dialog now presents IPP-over-USB devices as local printers.

## Changes

- Restrict IPP-over-USB detection to IPv4/IPv6 loopback addresses.
- Keep normal LAN IPP printers unaffected.
- Display IPP-over-USB devices under Local Printers instead of Network Printers.
- Preserve selection/scroll behavior for discovered IPP-over-USB printers.
- Add tests for IPv4 loopback, IPv6 loopback, LAN IPP, and non-IPP URIs.

## Testing

- `pytest -q test_dnssdresolve.py` — 14 passed
- `pytest -q test_PhysicalDevice.py` — 2 passed
- `git diff --check` — passed

The full test suite currently reports 16 passed and 1 unrelated failure in
`test_ppds.py::test_ppds` involving existing PPD ID matching tests.

I do not currently have a Xerox B235 available for physical hardware
validation.